### PR TITLE
Add signup and login button on home page using single url part

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -68,6 +68,27 @@ class TermApp extends React.Component {
       })
     } , false);
   }
+
+  renderHomePageActions() {
+    const { d: { session: { state } } } = this.props;
+    return state === 'out' && (
+      <div className="HomePage__lead__actions">
+        <a
+          className="HomePage__lead__actions__sign-up-button HomePage__lead__actions__button s-button"
+          href="#signup"
+        >
+          Sign Up
+        </a>
+        <a
+          className="s-button HomePage__lead__actions__button"
+          href="#account"
+        >
+          Login
+        </a>
+      </div>
+    );
+  }
+
   render() {
     let url = this.state.url;
     let urlParts = url.split('/');
@@ -79,8 +100,9 @@ class TermApp extends React.Component {
         <div className="HomePage__black">
           <div className="so-back">
             <div className="HomePage__lead">
-              <h2 className="HomePage__lead__title">Trade on the <a href="#exchange">Stellar Distributed Exchange</a></h2>
-              <p className="HomePage__lead__summary">StellarTerm is an <a href="https://github.com/irisli/stellarterm"  target="_blank" rel="nofollow noopener noreferrer">open source</a> client for the <a href="https://www.stellar.org/" target="_blank" rel="nofollow noopener noreferrer">Stellar network</a>. <br />Send, receive, and <a href="#exchange">trade</a> assets on the Stellar network easily with StellarTerm.</p>
+              <h2 className="HomePage__lead__title">Trade on the <a href="https://www.stellar.org/developers/guides/concepts/exchange.html"  target="_blank" rel="nofollow noopener noreferrer">Stellar Distributed Exchange</a></h2>
+              <p className="HomePage__lead__summary">StellarTerm is an <a href="https://github.com/irisli/stellarterm" target="_blank" rel="nofollow noopener noreferrer">open source</a> client for the <a href="https://www.stellar.org/" target="_blank" rel="nofollow noopener noreferrer">Stellar network</a>. <br />Send, receive, and <a href="#exchange">trade</a> assets on the Stellar network easily with StellarTerm.</p>
+              {this.renderHomePageActions()}
             </div>
           </div>
         </div>
@@ -138,7 +160,7 @@ class TermApp extends React.Component {
           <li>The StellarTerm website might be compromised.</li>
         </ul>
       </Generic>
-    } else if (urlParts[0] === 'account') {
+    } else if (['account', 'signup', 'ledger'].indexOf(urlParts[0]) > -1) {
       body = <Session d={this.d} urlParts={urlParts}></Session>
     } else if (urlParts[0] === 'markets') {
       body = <Markets d={this.d}></Markets>

--- a/src/components/Session.jsx
+++ b/src/components/Session.jsx
@@ -23,7 +23,7 @@ class Session extends React.Component {
     // KLUDGE: The event listeners are kinda messed up
     // Uncomment if state changes aren't working. But with the new refactor, this dead code should be removed
     // For now, it's just extra insurance
-    this.checkLoginStatus = () => {
+    this.checkLoginStatus = () => { 
       if (this.mounted) {
         if (this.props.d.session.state === 'in' || this.props.d.session.state === 'unfunded' ) {
           this.forceUpdate();
@@ -44,7 +44,7 @@ class Session extends React.Component {
     let state = d.session.state;
     let setupError = d.session.setupError;
     if (state === 'out') {
-      return <LoginPage setupError={setupError} d={d}></LoginPage>
+      return <LoginPage setupError={setupError} d={d} urlParts={this.props.urlParts}></LoginPage>
     } else if (state === 'unfunded') {
       return <Generic title={'Activate your account'}><Loading darker={true} left>
         <div className="s-alert s-alert--success">

--- a/src/components/Session/LoginPage.jsx
+++ b/src/components/Session/LoginPage.jsx
@@ -25,7 +25,6 @@ export default class LoginPage extends React.Component {
       newKeypair: null,
       bip32Path: '0',
       ledgerAdvanced: false,
-      currentTab: 'login', // 'login', 'createAccount', 'ledger'
     }
 
 
@@ -60,9 +59,6 @@ export default class LoginPage extends React.Component {
     this.toggleShow = (event) => {
       event.preventDefault();
       this.setState({show: !this.state.show});
-    }
-    this.setTab = (tabName) => {
-      this.setState({currentTab: tabName});
     }
     this.handleSubmit = (event) => {
       event.preventDefault();
@@ -114,7 +110,7 @@ export default class LoginPage extends React.Component {
 
     let body;
 
-    if (this.state.currentTab === 'login') {
+    if (this.props.urlParts[0] === 'account') {
       body = <div className="LoginPage__body">
         <div className="LoginPage__greenBox">
           <div className="LoginPage__form">
@@ -143,7 +139,7 @@ export default class LoginPage extends React.Component {
           </div>
         </div>
       </div>
-    } else if (this.state.currentTab === 'createAccount') {
+    } else if (this.props.urlParts[0] === 'signup') {
       body = <div className="LoginPage__body">
         <div className="LoginPage__greenBox">
           <div className="LoginPage__form">
@@ -162,7 +158,7 @@ export default class LoginPage extends React.Component {
           </div>
         </div>
       </div>
-    } else if (this.state.currentTab === 'ledger') {
+    } else if (this.props.urlParts[0] === 'ledger') {
       let loginForm;
       if (d.session.ledgerConnected) {
         let ledgerSetupErrorMessage;
@@ -271,13 +267,13 @@ export default class LoginPage extends React.Component {
         </div>
         <div className="LoginPage">
           <div className="LoginPage__sidebar">
-            <a className={'LoginPage__sidebar__tab' + (this.state.currentTab === 'createAccount' ? ' is-active' : '')} onClick={() => {this.setTab('createAccount')}}>
+            <a className={'LoginPage__sidebar__tab' + (this.props.urlParts[0] === 'signup' ? ' is-active' : '')} href="#signup">
               New account
             </a>
-            <a className={'LoginPage__sidebar__tab' + (this.state.currentTab === 'login' ? ' is-active' : '')} onClick={() => {this.setTab('login')}}>
+            <a className={'LoginPage__sidebar__tab' + (this.props.urlParts[0] === 'account' ? ' is-active' : '')} href="#account">
               Log in with key
             </a>
-            <a className={'LoginPage__sidebar__tab' + (this.state.currentTab === 'ledger' ? ' is-active' : '')} onClick={() => {this.setTab('ledger')}}>
+            <a className={'LoginPage__sidebar__tab' + (this.props.urlParts[0] === 'ledger' ? ' is-active' : '')} href="#ledger">
               <img className="LoginPage__sidebar__tab__img--invertible img--noSelect" src={images['ledger-logo']} alt="Ledger" width="75" height="20" />
             </a>
           </div>

--- a/src/styles/_HomePage.scss
+++ b/src/styles/_HomePage.scss
@@ -7,6 +7,17 @@
   padding-bottom: 120px;
   font-weight: 400;
 }
+
+.HomePage__lead__actions__sign-up-button {
+  margin-right: 8px;
+}
+
+.HomePage__lead__actions__button {
+  &:after {
+    border-bottom: none !important;
+  }
+}
+
 .HomePage__lead__title {
   font-size: $s-scale-c;
   font-weight: 300;


### PR DESCRIPTION
**Description**
@irisli refactored `Login.jsx` to render based on routes `account/signup/ledger` instead of react state. This resolves to wonky routing previous using `#account/signup`.

Also added code to not render the sign up buttons on homepage when the user is aleady signed in.

**Screenshot**
![stellerhome](https://user-images.githubusercontent.com/8507735/36005220-75ea86d2-0ceb-11e8-9c14-cc89d7ed7810.gif)
