### PR TITLE
Fix typo. 

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
     <!-- stellar-ledger-api is placed here due to a weird bug in gulp inliner -->
     <!-- Copy-paste is intentional as it reduces the amount of dependencies -->
     <!--
-      IMPORTANT DEVELOPER NOTE: This is not a straight copy of the stelar-ledger api
+      IMPORTANT DEVELOPER NOTE: This is not a straight copy of the stellar-ledger api
       This fixes a bug that crashes the client on iOs because u2f tries to go to a
       u2f url.
 


### PR DESCRIPTION
Context: closed pull request #208 because I accidentally included a change to .gitignore, in commit 0dd91f4e4d122028eb47f36d1f84de03236171c9, and I didn't merge on our master before submitting the pull request, either, so I thought I'd go ahead and do a little house cleaning.